### PR TITLE
Change to use the context.emit_print directly

### DIFF
--- a/HexChat/mymsg.py
+++ b/HexChat/mymsg.py
@@ -18,14 +18,13 @@ def privmsg_cb(word, word_eol, userdata, attrs):
 
 	if hexchat.nickcmp(sender, mynick) == 0 and hexchat.nickcmp(recipient, mynick) != 0:
 		hexchat.command('query -nofocus {}'.format(recipient))
-		hexchat.find_context(network, recipient).set()
 
 		if '\001ACTION' in msg:
 			for repl in ('\001ACTION', '\001'):
 				msg = msg.replace(repl, '')
-			hexchat.emit_print('Your Action', mynick, msg.strip(), time=attrs.time)
+			hexchat.find_context(network, recipient).emit_print('Your Action', mynick, msg.strip(), time=attrs.time)
 		else:
-			hexchat.emit_print('Your Message', mynick, msg, time=attrs.time)
+			hexchat.find_context(network, recipient).emit_print('Your Message', mynick, msg, time=attrs.time)
 
 		return hexchat.EAT_ALL
 


### PR DESCRIPTION
As it is now (at least on 2.9.6) the current method will dump messages into whatever context is open rather than where they should be going, this fixes that.
