### PR TITLE
Update pytabcomplete

### DIFF
--- a/HexChat/pytabcomplete.py
+++ b/HexChat/pytabcomplete.py
@@ -3,7 +3,7 @@ import hexchat
 
 __module_name__ = "PythonTabComplete"
 __module_author__ = "TingPing, FichteFoll"
-__module_version__ = "0.2"
+__module_version__ = "0.3"
 __module_description__ = "Tab-completes module attributes in Interactive Console"
 
 last_index = None
@@ -24,6 +24,7 @@ def keypress_cb(word, word_eol, userdata):
 		return
 	if not hexchat.get_info('channel') == '>>python<<':
 		return
+	shift_key_is_down = bool(int(word[1]) & 1)  # check if shift modifier is hold
 
 	text = hexchat.get_info('inputbox')
 	pos = hexchat.get_prefs('state_cursor')
@@ -50,7 +51,8 @@ def keypress_cb(word, word_eol, userdata):
 	else:
 		# same context, insert next completion
 		completions = last_completes
-		index = (last_index + 1) % len(completions)
+		direction = 1 if not shift_key_is_down else -1
+		index = (last_index + direction) % len(completions)
 
 	complete_text = completions[index]
 

--- a/HexChat/pytabcomplete.py
+++ b/HexChat/pytabcomplete.py
@@ -2,61 +2,73 @@ from __future__ import print_function
 import hexchat
 
 __module_name__ = "PythonTabComplete"
-__module_author__ = "TingPing"
-__module_version__ = "0"
-__module_description__ = "Tab completes modules in Interactive Console"
+__module_author__ = "TingPing, FichteFoll"
+__module_version__ = "0.2"
+__module_description__ = "Tab-completes module attributes in Interactive Console"
 
-lastmodule = ''
-lastcomplete = 0
-lasttext = ''
+last_index = None
+last_completes = None
+last_text = None
+last_pos = None
+
+exec_scope = {}
+
 
 def keypress_cb(word, word_eol, userdata):
-	global lastmodule
-	global lastcomplete
-	global lasttext
+	global last_index
+	global last_completes
+	global last_text
+	global last_pos
 
-	if not word[0] == '65289': # Tab
+	if not word[0] == '65289':  # Tab
 		return
 	if not hexchat.get_info('channel') == '>>python<<':
 		return
 
 	text = hexchat.get_info('inputbox')
-	#pos = hexchat.get_prefs('state_cursor') # TODO: allow completing mid line
-	if not text:# or not pos:
+	pos = hexchat.get_prefs('state_cursor')
+	if not text:
 		return
 
-	try:
-		module = text.split(' ')[-1].split('.')[0]
-	except IndexError:
+	base = text[:pos].split(' ')[-1]
+	module, _, prefix = base.rpartition('.')
+	if not module:
+		# can not dir() the console's interpreter state sadly
 		return
 
-	if lastmodule != module:
-		lastcomplete = 0
-		lasttext = text
-	lastmodule = module
-
-	try:
-		exec('import {}'.format(module)) # Has to be imported to dir() it
-		completes = eval('dir({})'.format(module))
-		if lastcomplete + 1 < len(completes):
-			lastcomplete = lastcomplete + 1
-		else:
-			lastcomplete = 0
-	except (NameError, SyntaxError, ImportError):
-		return
-
-	if lasttext[-1] != '.':
-		sep = '.'
+	if last_text != text or last_pos != pos:
+		# new completion context
+		try:
+			exec('import {}'.format(module), exec_scope)  # Has to be imported to dir() it
+			completions = eval('dir({})'.format(module), exec_scope)
+		except (NameError, SyntaxError, ImportError):
+			return
+		completions = [c for c in completions if c.startswith(prefix)]
+		if not completions:
+			return
+		index = 0
 	else:
-		sep = ''
-	
-	newtext	= lasttext + sep + completes[lastcomplete]
+		# same context, insert next completion
+		completions = last_completes
+		index = (last_index + 1) % len(completions)
 
-	hexchat.command('settext {}'.format(newtext))
-	hexchat.command('setcursor {}'.format(len(newtext)))
+	complete_text = completions[index]
+
+	new_text = text[:pos - len(prefix)] + complete_text + text[pos:]
+	new_pos = pos - len(prefix) + len(complete_text)
+
+	hexchat.command('settext {}'.format(new_text))
+	hexchat.command('setcursor {}'.format(new_pos))
+
+	last_index = index
+	last_completes = completions
+	last_text = new_text
+	last_pos = new_pos
+
 
 def unload_cb(userdata):
 	print(__module_name__, 'version', __module_version__, 'unloaded.')
+
 
 hexchat.hook_print('Key Press', keypress_cb)
 hexchat.hook_unload(unload_cb)


### PR DESCRIPTION
Now supports the following, where `|` represents the caret:
```py
print(hexchat.EAT|)
# <tab>
print(hexchat.EAT_ALL|)
# <tab>
print(hexchat.EAT_HEXCHAT|)
# <tab>
print(hexchat.EAT_NONE|)
# <tab>
print(hexchat.EAT_PLUGIN|)
# <tab>
print(hexchat.EAT_XCHAT|)
# <tab>
print(hexchat.EAT_ALL|)
# ...
```

Should in theory also support shift+tab, but that didn't work on my machine.

For safety measures I also added an `exec_scope` which will be passed to `exec` and `dir` as the globals argument.