### PR TITLE
Improved handling of mode changes in buffextras.lua

### DIFF
--- a/HexChat/buffextras.lua
+++ b/HexChat/buffextras.lua
@@ -38,7 +38,12 @@ hexchat.hook_server_attrs('PRIVMSG', function (word, word_eol, attrs)
 	elseif is_event('kicked') then
 		emit('Kick', nick, word[6], channel, strip_brackets(word_eol[8]))
 	elseif is_event('set mode') then
-		emit('Raw Modes', nick, string.format('%s %s', channel, word_eol[7]))
+		if nick == nil then
+			server = word[4]:match('^:([^!]+)$')
+			emit('Channel Mode Generic', server, string.format('%s %s', word_eol[7]:match('^(.*%S)'), channel))
+		else
+			emit('Channel Mode Generic', nick, string.format('%s %s', word_eol[7]:match('^(.*%S)'), channel))
+		end
 	else
 		return -- Unknown event
 	end


### PR DESCRIPTION
I made some changes to buffextras.lua to try to improve the handling of mode changes.

Here's what HexChat normally displays for some activity in a channel:
![1 - original](https://cloud.githubusercontent.com/assets/376450/18222076/49243efe-7151-11e6-9b83-26e5d06d0fb8.png)

And here is what buffextras turns this into in ZNC 1.6.3:
![2 - buffextras](https://cloud.githubusercontent.com/assets/376450/18222082/5fb01918-7151-11e6-9490-62ca2746d055.png)

The original buffextras.lua doesn't quite handle the mode changes properly. The mode changes from the server are unreadable, and the changes from the user clearly have a different format from what is normally used:
![3 - plugin](https://cloud.githubusercontent.com/assets/376450/18222090/a38bf968-7151-11e6-95b9-34996d763f43.png)

After my changes, this is the result:
![4 - plugin-mod](https://cloud.githubusercontent.com/assets/376450/18222092/aa40e9da-7151-11e6-84f1-1f14c9859278.png)

It's not perfect. Obviously, HexChat normally does some parsing of the mode changes and even breaks them apart so that it can display a nice message for particular changes (e.g. +b or +l). This is not implemented here, but I think it's at least an improvement.

Thanks for considering this change!

Sam