### PR TITLE
Updated buffextras.lua for new znc version

### DIFF
--- a/HexChat/buffextras.lua
+++ b/HexChat/buffextras.lua
@@ -25,8 +25,17 @@ hexchat.hook_server_attrs('PRIVMSG', function (word, word_eol, attrs)
 		emit('Join', nick, channel, host)
 	elseif is_event('quit with message') then
 		emit('Quit', nick, strip_brackets(word_eol[8]), host)
+	elseif is_event('quit:') then
+		emit('Quit', nick, word_eol[6], host)
 	elseif is_event('parted with message') then
 		local reason = strip_brackets(word_eol[8])
+		if reason ~= '' then
+			emit('Part with Reason', nick, host, channel, reason)
+		else
+			emit('Part', nick, host, channel)
+		end
+	elseif is_event('parted:') then
+		local reason = word_eol[6]
 		if reason ~= '' then
 			emit('Part with Reason', nick, host, channel, reason)
 		else
@@ -37,7 +46,11 @@ hexchat.hook_server_attrs('PRIVMSG', function (word, word_eol, attrs)
 	elseif is_event('changed the topic to') then
 		emit('Topic Change', nick, word_eol[9], channel)
 	elseif is_event('kicked') then
-		emit('Kick', nick, word[6], channel, strip_brackets(word_eol[8]))
+		if word[7] == "Reason:" then
+			emit('Kick', nick, word[6], channel, strip_brackets(word_eol[8]))
+		else
+			emit('Kick', nick, word[6], channel, word_eol[9])
+		end
 	elseif is_event('set mode') then
 		emit('Raw Modes', nick, string.format('%s %s', channel, word_eol[7]))
 	else


### PR DESCRIPTION
In https://github.com/znc/znc/commit/bb27cd964c45a69ceca2fdaafcf970bca1ee68b6, the strings produced by buffextras were made translateable and changed. This commit makes buffextras.lua recognize the new (default) strings while staying backwards-compatible with the old ones.