### PR TITLE
Show (radio stream) instead of non existing length if a radio stream …

### DIFF
--- a/HexChat/nowplaying.lua
+++ b/HexChat/nowplaying.lua
@@ -182,7 +182,9 @@ local function print_nowplaying (player)
 				-- formatted timestamps
 				replacements['position'] = format_timestamp(position)
 				replacements['length'] = format_timestamp(metadata['mpris:length'])
-				-- shorthands
+				if replacements['length'] == nil then
+					replacements['length'] = '(radio stream)'
+				end
 				replacements['title'] = metadata['xesam:title']
 				replacements['album'] = metadata['xesam:album']
 				-- other


### PR DESCRIPTION
…is playing.

When a radio stream was playing, and '/np' was used. It would show it like this:

is now playing SONG by ARTIST [78:41/${length=default}]
or
is now playing SONG by ARTIST [78:41/${length=0}]

It just didn't load any default value.